### PR TITLE
Support pollenrich for external tasks

### DIFF
--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
@@ -35,7 +35,7 @@ public class CamundaBpmPollExternalTasksEndpointImpl extends DefaultPollingEndpo
     private static final Logger logger = Logger.getLogger(
             CamundaBpmPollExternalTasksEndpointImpl.class.getCanonicalName());
 
-    private final CamundaBpmComponent component;
+    private CamundaBpmComponent component;
 
     // parameters
     private final String topic;

--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/component/CamundaBpmPollExternalTasksEndpointImpl.java
@@ -22,7 +22,6 @@ import java.util.Map;
 import java.util.logging.Logger;
 
 import org.apache.camel.Consumer;
-import org.apache.camel.PollingConsumer;
 import org.apache.camel.Processor;
 import org.apache.camel.Producer;
 import org.apache.camel.converter.TimePatternConverter;
@@ -36,7 +35,7 @@ public class CamundaBpmPollExternalTasksEndpointImpl extends DefaultPollingEndpo
     private static final Logger logger = Logger.getLogger(
             CamundaBpmPollExternalTasksEndpointImpl.class.getCanonicalName());
 
-    private CamundaBpmComponent component;
+    private final CamundaBpmComponent component;
 
     // parameters
     private final String topic;
@@ -170,16 +169,6 @@ public class CamundaBpmPollExternalTasksEndpointImpl extends DefaultPollingEndpo
         consumer.setMaxMessagesPerPoll(maxTasksPerPoll);
 
         return consumer;
-
-    }
-
-    @Override
-    public PollingConsumer createPollingConsumer() throws Exception {
-
-        return null;
-        // return new
-        // org.camunda.bpm.camel.component.externaltasks.PollingConsumer(this,
-        // topic);
 
     }
 


### PR DESCRIPTION
With this change polling Camunda's database can be done optionally:

```java
        from("scheduler:Example"
                + "?initialDelay=60000"
                + "&delay=5000")
            .process(exchange -> {
                final boolean enabled = Boolean.TRUE.equals(System.getProperty("example.enabled"));
                exchange.setProperty("ExampleEnabled", enabled);
            })
            .choice()
            .when(simple("${property.ExampleEnabled} == true"))
                .threads()
                .pollEnrich("camunda-bpm:poll-externalTasks"
                        + "?topic=ExampleTopic"
                        + "&workerId=ExampleWorker"
                        + "&async=true"
                        + "&lockDuration=6h"
                        + "&retries=0"
                        + "&maxTasksPerPoll=1",
                        100)
                 .process(exchange -> {
                     exchange.setProperty(CamundaBpmConstants.EXCHANGE_HEADER_TASK,
                                          exchange.getIn().getHeader(CamundaBpmConstants.EXCHANGE_HEADER_TASK));
                 })
                 .choice()
                 .when(simple("${property." + CamundaBpmConstants.EXCHANGE_HEADER_TASK + "} != null"))
....
                    .to("camunda-bpm://async-externalTask")
                .end()
            .end();
```

Cheers,
Stephan