### PR TITLE
Bpmn mapped camel exception

### DIFF
--- a/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/common/CamelService.java
+++ b/camunda-bpm-camel-common/src/main/java/org/camunda/bpm/camel/common/CamelService.java
@@ -18,9 +18,12 @@ public interface CamelService {
    * @param endpointUri
    *          an Camel {@link org.apache.camel.Endpoint} URI
    *
+   * @exception Exception BpmnError: Raises business error in workflow allowing boundary error handling
+   *                      Any other cheched or unchecked exception raises technical error stopping workflow at service task
+   * 
    * @return the result of the execution of the Camel route
    */
-  public Object sendTo(String endpointUri);
+  public Object sendTo(String endpointUri) throws Exception;
 
   /**
    * Sends the specified process instance variables as a map to an Camel
@@ -36,9 +39,12 @@ public interface CamelService {
    *          list of process variable names. Empty string sends no variables,
    *          null value sends all
    *
+   * @exception Exception BpmnError: Raises business error in workflow allowing boundary error handling
+   *                      Any other cheched or unchecked exception raises technical error stopping workflow at service task
+   * 
    * @return the result of the execution of the Camel route
    */
-  public Object sendTo(String endpointUri, String processVariables);
+  public Object sendTo(String endpointUri, String processVariables) throws Exception;
 
   /**
    * Sends the specified process instance variables as a map to an Camel
@@ -57,9 +63,12 @@ public interface CamelService {
    *          value for correlation of Response. Route for response must contain
    *          a parameter correlationKeyName with the name of the process
    *          variable which is used for correlation
+   * 
+   * @exception Exception BpmnError: Raises business error in workflow allowing boundary error handling
+   *                      Any other cheched or unchecked exception raises technical error stopping workflow at service task
    *
    * @return the result of the execution of the Camel route
    */
   public Object sendTo(String endpointUri, String processVariables,
-      String correlationKey);
+      String correlationKey) throws Exception;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <mockito.version>2.28.2</mockito.version>
     <powermock.version>2.0.5</powermock.version>
     <h2.version>1.4.197</h2.version>
-    <!--maven.compiler.release>8</maven.compiler.release-->
+    <maven.compiler.release>8</maven.compiler.release>
      <!-- overwrite value from parent to allow Java 11-->
     <plugin.version.javadoc>3.2.0</plugin.version.javadoc>
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <mockito.version>2.28.2</mockito.version>
     <powermock.version>2.0.5</powermock.version>
     <h2.version>1.4.197</h2.version>
-    <maven.compiler.release>8</maven.compiler.release>
+    <!--maven.compiler.release>8</maven.compiler.release-->
      <!-- overwrite value from parent to allow Java 11-->
     <plugin.version.javadoc>3.2.0</plugin.version.javadoc>
   </properties>


### PR DESCRIPTION
Any exception being raised in a called Camel route was not being propagated back to the Service Task in the BPMN process.

I believe this would also relate to the following open issues:
 - Stop camunda 'route' on camel exception. #49
 - Sync outbound call using ${camel.sendTo(...)} does not throw exception #25

The following references cover the difference between business and technical exceptions in a service task. 
   https://docs.camunda.org/get-started/rpa/error-handling/
   https://docs.camunda.org/manual/7.15/reference/bpmn20/events/error-events/

The pull will patch the code by interrogating the return Camel Exchange to determine if an exception has been raised within the camel route.

If the Camel route raised the specific BpmnError exception, then the error will be propagated back to the Camanda service task where a boundary error can be used to handle the business error.

If the Camel route throws any other exception (checked or unchecked), this will then be propagated to the service task as a technical error causing the service task to stop in the Camanda process.
